### PR TITLE
Improve rotation algorithm and introduce threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,5 +55,6 @@ there are the following args.
 --sleep // Set sleep millis (500)
 --display // Set Display Device (eDP-1)
 --touchscreen // Set Touchscreen Device X11 (ELAN0732:00 04F3:22E1)
+--threshold // Set a rotation threshold between 0 and 1 (0.5)
 
 ```


### PR DESCRIPTION
This fixes issue #8 .
The rotation algorithm has been modified to use a vector distance approach. As a result, the screen rotation now holds state and isn't solely dependent on current accelerometer readings. This allows, for example, placing the screen on a flat surface without a rotation change triggering. A command line option to vary the threshold was also added.