### PR TITLE
Optionally disable keyboards when rotated

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rot8"
 version = "0.1.2"
-authors = ["efernau <e.fernau@efero.de>"]
+authors = ["efernau <e.fernau@efero.de>", "deadly_platypus <mail@geth.systems>"]
 license = "MIT"
 description = "automatic display rotation using built-in accelerometer"
 homepage = "https://github.com/efernau/rot8"

--- a/README.md
+++ b/README.md
@@ -55,5 +55,5 @@ there are the following args.
 --sleep // Set sleep millis (500)
 --display // Set Display Device (eDP-1)
 --touchscreen // Set Touchscreen Device X11 (ELAN0732:00 04F3:22E1)
--k, --disable-keyboard // Disable keyboards when rotated
+-k, --disable-keyboard // Disable keyboards when rotated (Sway only)
 ```

--- a/README.md
+++ b/README.md
@@ -55,6 +55,5 @@ there are the following args.
 --sleep // Set sleep millis (500)
 --display // Set Display Device (eDP-1)
 --touchscreen // Set Touchscreen Device X11 (ELAN0732:00 04F3:22E1)
---keyboard // Set keyboard to deactivate upon rotation
-
+-k, --disable-keyboard // Disable keyboards when rotated
 ```

--- a/README.md
+++ b/README.md
@@ -55,5 +55,6 @@ there are the following args.
 --sleep // Set sleep millis (500)
 --display // Set Display Device (eDP-1)
 --touchscreen // Set Touchscreen Device X11 (ELAN0732:00 04F3:22E1)
+--keyboard // Set keyboard to deactivate upon rotation
 
 ```


### PR DESCRIPTION
I have a 2-in-1 laptop, and I kept on pressing keys when in tablet mode.  This disables keyboard button presses when the screen is in its "normal" orientation.  However, it only works while using Sway, since I don't know how Xorg works.