### PR TITLE
Add oneshot mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -149,6 +149,11 @@ fn main() -> Result<(), String> {
     };
 
     let mut args = vec![
+        Arg::with_name("oneshot")
+            .long("oneshot")
+            .short("O")
+            .help("Instead of running continuously, just check the accelerometer and perform screen rotation if necessary once")
+            .takes_value(false),
         Arg::with_name("sleep")
             .default_value("500")
             .long("sleep")
@@ -225,6 +230,7 @@ fn main() -> Result<(), String> {
 
     let matches = cmd_lines.get_matches();
 
+    let oneshot = matches.is_present("oneshot");
     let sleep = matches.value_of("sleep").unwrap_or("default.conf");
     let display = matches.value_of("display").unwrap_or("default.conf");
     let touchscreen = matches.value_of("touchscreen").unwrap_or("default.conf");
@@ -392,6 +398,11 @@ fn main() -> Result<(), String> {
             }
             old_state = new_state;
         }
+
+        if oneshot {
+            return Ok(());
+        }
+
         thread::sleep(Duration::from_millis(sleep.parse::<u64>().unwrap_or(0)));
     }
 }


### PR DESCRIPTION
Adds the `--oneshot`/`-O` flag which updates the screen rotation just once
instead of continuously. The use case for this is having a button that
allows the user to apply screen rotation manually, instead of having it
running automatically all the time.

---

I find this better for me on my Surface Go 2 when I'm holding it like a clipboard - I tend to accidentally tilt it a lot and trigger rotation, and I don't want it to rotate automatically in that use case anyway. With this change, I can assign one of the physical volume keys on the device to run `rot8 --oneshot` and then I have manual control over screen rotation.