### PR TITLE
Reduce binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,7 @@ glob = "0.3"
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+[profile.release]
+strip = true
+lto = true


### PR DESCRIPTION
Hi!
I made a PR with 2 changes to how the release version is compiled to reduce the binary size.
The changes are:
- Set `strip` to `true`: This removes the debug info and the symbols (only when compiled for release). [More information.](https://github.com/johnthagen/min-sized-rust#strip-symbols-from-binary)
- Set `lto` to `true`: This enables the link time optimization. [More information.](https://github.com/johnthagen/min-sized-rust#strip-symbols-from-binary)

These changes reduce the binary size from 6.2mb to 1.9mb.

## Results
### `master` branch
![binary_size_master](https://user-images.githubusercontent.com/2772065/180904172-8bbf103e-bdd4-4203-b0d0-f3439bfb3c47.png)

### `reduce_binary_size` branch
![binary_size_reduced](https://user-images.githubusercontent.com/2772065/180904276-a1572810-90ff-4bbe-acc4-388ef39ca1be.png)


