### PR TITLE
Use output_management_v1 protocol for wayland rotation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,13 +34,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "3.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ed5341b2301a26ab80be5cbdced622e80ed808483c52e45e3310a877d3b37d7"
 dependencies = [
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
  "indexmap",
  "strsim",
@@ -56,6 +77,21 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "dlib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "glob"
@@ -87,9 +123,25 @@ checksum = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 
 [[package]]
 name = "libc"
-version = "0.2.62"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+
+[[package]]
+name = "libloading"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb"
+dependencies = [
+ "cfg-if",
+ "windows-sys",
+]
+
+[[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
@@ -98,18 +150,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.3"
+name = "pkg-config"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98a83a9f9b331f54b924e68a66acb1bb35cb01fb0a23645139967abefb697e8"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -147,6 +235,8 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "wayland-client",
+ "wayland-protocols-wlr",
 ]
 
 [[package]]
@@ -154,6 +244,12 @@ name = "ryu"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "serde"
@@ -185,6 +281,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "strsim"
@@ -219,10 +321,89 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb88c68ca70d8ce256fc3407d694472980ca3f2d4ae605b88500338f1819b55b"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "nix",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd523ec07b847d443f615f90f568130e83f39adf8251517b362f1cbd3d0aaf43"
+dependencies = [
+ "bitflags 2.4.0",
+ "nix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e253d7107ba913923dc253967f35e8561a3c65f914543e46843c88ddd729e21c"
+dependencies = [
+ "bitflags 2.4.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
+dependencies = [
+ "bitflags 2.4.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb8e28403665c9f9513202b7e1ed71ec56fde5c107816843fb14057910b2c09c"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15a0c8eaff5216d07f226cb7a549159267f3467b289d9a2e52fd3ef5aae2b7af"
+dependencies = [
+ "dlib",
+ "log",
+ "pkg-config",
+]
 
 [[package]]
 name = "winapi"
@@ -254,3 +435,69 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ glob = "0.3"
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+wayland-client = "0.31.0"
+wayland-protocols-wlr = { version = "0.2.0", features = ["client"] }
 
 [profile.release]
 strip = true

--- a/README.md
+++ b/README.md
@@ -2,10 +2,13 @@
 
 ## automatic display rotation using built-in accelerometer
 
-Automatic rotate modern Linux desktop screen and input devices. Handy for
-convertible touchscreen notebooks like HP Spectre x360, Lenovo IdeaPad Flex or Linux phone like Pinephone.
+Automatically rotate modern Linux desktop screen and input devices. Handy for
+convertible touchscreen notebooks like HP Spectre x360, Lenovo IdeaPad Flex
+or Linux phone like Pinephone.
 
-Compatible with [sway](http://swaywm.org/) and [X11](https://www.x.org/wiki/Releases/7.7/).
+Compatible with [X11](https://www.x.org/wiki/Releases/7.7/) and Wayland
+compositors which support the `wlr_output_management_v1` protocol (Like
+[sway](http://swaywm.org/) and [hyprland](https://hyprland.org/)).
 
 ### installation
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ cargo install rot8
 
 ### usage
 
-For Sway map your input to the output device:
+Map your inputs to the output device as necessary. e.g. for sway:
 
 ```
 
@@ -51,7 +51,7 @@ $ swaymsg input <INPUTDEVICE> map_to_output <OUTPUTDEVICE>
 
 ```
 
-Call rot8 from sway configuration file ~/.config/sway/config:
+Call rot8 from your compositor configuration. e.g. for sway:
 
 ```
 

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -1,9 +1,8 @@
 use crate::Orientation;
 
 pub trait AppLoop {
-    fn tick_always(&mut self) -> ();
-    fn tick(&mut self, new_state: &Orientation) -> ();
-    fn get_rotation_state(&self, display: &str) -> Result<String, String>;
+    fn change_rotation_state(&mut self, new_state: &Orientation) -> ();
+    fn get_rotation_state(&mut self) -> Result<String, String>;
 }
 
 pub mod sway;

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -1,9 +1,11 @@
+use crate::Orientation;
 use wayland_client::protocol::wl_output::Transform;
 
-use crate::Orientation;
-
 pub trait DisplayManager {
+    /// Change the orientation of the target display.
     fn change_rotation_state(&mut self, new_state: &Orientation) -> ();
+
+    /// Get the current transformation of the target display.
     fn get_rotation_state(&mut self) -> Result<Transform, String>;
 }
 

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -3,7 +3,7 @@ use wayland_client::protocol::wl_output::Transform;
 
 pub trait DisplayManager {
     /// Change the orientation of the target display.
-    fn change_rotation_state(&mut self, new_state: &Orientation) -> ();
+    fn change_rotation_state(&mut self, new_state: &Orientation);
 
     /// Get the current transformation of the target display.
     fn get_rotation_state(&mut self) -> Result<Transform, String>;

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -1,0 +1,11 @@
+use crate::Orientation;
+
+pub trait AppLoop {
+    fn tick_always(&mut self) -> ();
+    fn tick(&mut self, new_state: &Orientation) -> ();
+    fn get_rotation_state(&self, display: &str) -> Result<String, String>;
+}
+
+pub mod sway;
+pub mod wlroots;
+pub mod xorg;

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -1,6 +1,6 @@
 use crate::Orientation;
 
-pub trait AppLoop {
+pub trait DisplayManager {
     fn change_rotation_state(&mut self, new_state: &Orientation) -> ();
     fn get_rotation_state(&mut self) -> Result<String, String>;
 }

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -1,8 +1,10 @@
+use wayland_client::protocol::wl_output::Transform;
+
 use crate::Orientation;
 
 pub trait DisplayManager {
     fn change_rotation_state(&mut self, new_state: &Orientation) -> ();
-    fn get_rotation_state(&mut self) -> Result<String, String>;
+    fn get_rotation_state(&mut self) -> Result<Transform, String>;
 }
 
 pub mod sway;

--- a/src/backends/sway.rs
+++ b/src/backends/sway.rs
@@ -5,17 +5,17 @@ use wayland_client::Connection;
 
 use crate::Orientation;
 
-use super::{wlroots::WaylandLoop, AppLoop};
+use super::{wlroots::WaylandBackend, DisplayManager};
 
-pub struct SwayLoop {
-    wayland_loop: WaylandLoop,
+pub struct SwayBackend {
+    wayland_backend: WaylandBackend,
     manage_keyboard: bool,
 }
 
-impl SwayLoop {
-    pub fn new(conn: Connection, target_display: &str, manage_keyboard: bool) -> SwayLoop {
-        SwayLoop {
-            wayland_loop: WaylandLoop::new(conn, target_display),
+impl SwayBackend {
+    pub fn new(conn: Connection, target_display: &str, manage_keyboard: bool) -> SwayBackend {
+        SwayBackend {
+            wayland_backend: WaylandBackend::new(conn, target_display),
             manage_keyboard,
         }
     }
@@ -45,9 +45,9 @@ impl SwayLoop {
         keyboards
     }
 }
-impl AppLoop for SwayLoop {
+impl DisplayManager for SwayBackend {
     fn change_rotation_state(&mut self, new_state: &Orientation) {
-        self.wayland_loop.change_rotation_state(new_state);
+        self.wayland_backend.change_rotation_state(new_state);
 
         if !self.manage_keyboard {
             return;
@@ -58,7 +58,7 @@ impl AppLoop for SwayLoop {
         } else {
             "disabled"
         };
-        for keyboard in &SwayLoop::get_keyboards() {
+        for keyboard in &SwayBackend::get_keyboards() {
             Command::new("swaymsg")
                 .arg("input")
                 .arg(keyboard)
@@ -72,6 +72,6 @@ impl AppLoop for SwayLoop {
     }
 
     fn get_rotation_state(&mut self) -> Result<String, String> {
-        self.wayland_loop.get_rotation_state()
+        self.wayland_backend.get_rotation_state()
     }
 }

--- a/src/backends/sway.rs
+++ b/src/backends/sway.rs
@@ -1,0 +1,108 @@
+use std::process::Command;
+
+use serde::Deserialize;
+use serde_json::Value;
+use wayland_client::Connection;
+
+use crate::Orientation;
+
+use super::{wlroots::WaylandLoop, AppLoop};
+
+#[derive(Deserialize)]
+struct SwayOutput {
+    name: String,
+    transform: String,
+}
+
+pub struct SwayLoop {
+    wayland_loop: WaylandLoop,
+    manage_keyboard: bool,
+}
+
+impl SwayLoop {
+    pub fn new(conn: Connection, target_display: &str, manage_keyboard: bool) -> SwayLoop {
+        SwayLoop {
+            wayland_loop: WaylandLoop::new(conn, target_display),
+            manage_keyboard,
+        }
+    }
+
+    fn get_keyboards() -> Vec<String> {
+        let raw_inputs = String::from_utf8(
+            Command::new("swaymsg")
+                .arg("-t")
+                .arg("get_inputs")
+                .arg("--raw")
+                .output()
+                .expect("Swaymsg get inputs command failed")
+                .stdout,
+        )
+        .unwrap();
+
+        let mut keyboards = vec![];
+        let deserialized: Vec<Value> =
+            serde_json::from_str(&raw_inputs).expect("Unable to deserialize swaymsg JSON output");
+        for output in deserialized {
+            let input_type = output["type"].as_str().unwrap();
+            if input_type == "keyboard" {
+                keyboards.push(output["identifier"].to_string());
+            }
+        }
+
+        keyboards
+    }
+}
+impl AppLoop for SwayLoop {
+    fn tick_always(&mut self) -> () {
+        self.wayland_loop.tick_always();
+    }
+    fn tick(&mut self, new_state: &Orientation) {
+        self.wayland_loop.tick(new_state);
+
+        if !self.manage_keyboard {
+            return;
+        }
+
+        let keyboard_state = if new_state.new_state == "normal" {
+            "enabled"
+        } else {
+            "disabled"
+        };
+        for keyboard in &SwayLoop::get_keyboards() {
+            Command::new("swaymsg")
+                .arg("input")
+                .arg(keyboard)
+                .arg("events")
+                .arg(keyboard_state)
+                .spawn()
+                .expect("Swaymsg keyboard command failed to start")
+                .wait()
+                .expect("Swaymsg keyboard command wait failed");
+        }
+    }
+
+    fn get_rotation_state(&self, display: &str) -> Result<String, String> {
+        let raw_rotation_state = String::from_utf8(
+            Command::new("swaymsg")
+                .arg("-t")
+                .arg("get_outputs")
+                .arg("--raw")
+                .output()
+                .expect("Swaymsg get outputs command failed to start")
+                .stdout,
+        )
+        .unwrap();
+        let deserialized: Vec<SwayOutput> = serde_json::from_str(&raw_rotation_state)
+            .expect("Unable to deserialize swaymsg JSON output");
+        for output in deserialized {
+            if output.name == display {
+                return Ok(output.transform);
+            }
+        }
+
+        Err(format!(
+            "Unable to determine rotation state: display {} not found in 'swaymsg -t get_outputs'",
+            display
+        ))
+    }
+}

--- a/src/backends/sway.rs
+++ b/src/backends/sway.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 use serde_json::Value;
-use wayland_client::{protocol::wl_output::Transform, Connection};
+use wayland_client::protocol::wl_output::Transform;
 
 use crate::Orientation;
 
@@ -13,9 +13,9 @@ pub struct SwayBackend {
 }
 
 impl SwayBackend {
-    pub fn new(conn: Connection, target_display: &str, manage_keyboard: bool) -> SwayBackend {
+    pub fn new(wayland_backend: WaylandBackend, manage_keyboard: bool) -> Self {
         SwayBackend {
-            wayland_backend: WaylandBackend::new(conn, target_display),
+            wayland_backend,
             manage_keyboard,
         }
     }
@@ -45,6 +45,7 @@ impl SwayBackend {
         keyboards
     }
 }
+
 impl DisplayManager for SwayBackend {
     fn change_rotation_state(&mut self, new_state: &Orientation) {
         self.wayland_backend.change_rotation_state(new_state);

--- a/src/backends/sway.rs
+++ b/src/backends/sway.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 
 use serde_json::Value;
-use wayland_client::Connection;
+use wayland_client::{protocol::wl_output::Transform, Connection};
 
 use crate::Orientation;
 
@@ -53,7 +53,7 @@ impl DisplayManager for SwayBackend {
             return;
         }
 
-        let keyboard_state = if new_state.new_state == "normal" {
+        let keyboard_state = if new_state.wayland_state == Transform::Normal {
             "enabled"
         } else {
             "disabled"
@@ -71,7 +71,7 @@ impl DisplayManager for SwayBackend {
         }
     }
 
-    fn get_rotation_state(&mut self) -> Result<String, String> {
+    fn get_rotation_state(&mut self) -> Result<Transform, String> {
         self.wayland_backend.get_rotation_state()
     }
 }

--- a/src/backends/wlroots.rs
+++ b/src/backends/wlroots.rs
@@ -126,7 +126,7 @@ impl Dispatch<wl_registry::WlRegistry, ()> for AppData {
             version,
         } = event
         {
-            println!("[{}] {} v{}", name, interface, version);
+            // println!("[{}] {} v{}", name, interface, version);
             if interface == "zwlr_output_manager_v1" {
                 state.output_manager =
                     Some(registry.bind::<ZwlrOutputManagerV1, (), AppData>(name, version, qh, ()));
@@ -145,7 +145,7 @@ impl Dispatch<ZwlrOutputManagerV1, ()> for AppData {
         _: &QueueHandle<AppData>,
     ) {
         if let zwlr_output_manager_v1::Event::Done { serial } = event {
-            println!("Current config: {}", serial);
+            // println!("Current config: {}", serial);
             state.current_config_serial = Some(serial);
         }
     }
@@ -167,7 +167,7 @@ impl Dispatch<ZwlrOutputHeadV1, ()> for AppData {
         match event {
             zwlr_output_head_v1::Event::Name { name } => {
                 if name == state.target_display_name {
-                    println!("Found target display: {}", name);
+                    // println!("Found target display: {}", name);
                     state.target_head = Some(head.clone());
                 }
             }
@@ -207,15 +207,15 @@ impl Dispatch<ZwlrOutputConfigurationV1, ()> for AppData {
     ) {
         match event {
             zwlr_output_configuration_v1::Event::Succeeded => {
-                println!("Config applied successfully.");
+                // println!("Config applied successfully.");
                 config.destroy();
             }
             zwlr_output_configuration_v1::Event::Failed => {
-                println!("Failed to apply new config.");
+                // println!("Failed to apply new config.");
                 config.destroy();
             }
             zwlr_output_configuration_v1::Event::Cancelled => {
-                println!("Config application cancelled.");
+                // println!("Config application cancelled.");
                 config.destroy();
             }
             _ => {}

--- a/src/backends/wlroots.rs
+++ b/src/backends/wlroots.rs
@@ -28,9 +28,15 @@ impl WaylandBackend {
         let mut event_queue = conn.new_event_queue();
         let _registry = wl_display.get_registry(&event_queue.handle(), ());
         let mut state = AppData::new(&mut event_queue, target_display.to_string());
-        event_queue.roundtrip(&mut state).unwrap();
-        // Roundtrip a second time to sync the outputs
-        event_queue.roundtrip(&mut state).unwrap();
+        // Roundtrip twice to sync the outputs
+        for _ in 0..2 {
+            event_queue.roundtrip(&mut state).map_err(|e| {
+                format!(
+                    "Failed to communicate with the wayland socket: {}",
+                    e.to_string()
+                )
+            })?;
+        }
 
         state
             .output_manager

--- a/src/backends/wlroots.rs
+++ b/src/backends/wlroots.rs
@@ -13,15 +13,15 @@ use wayland_protocols_wlr::output_management::v1::client::{
 
 use crate::Orientation;
 
-use super::AppLoop;
+use super::DisplayManager;
 
-pub struct WaylandLoop {
+pub struct WaylandBackend {
     state: AppData,
     event_queue: EventQueue<AppData>,
 }
 
-impl WaylandLoop {
-    pub fn new(conn: Connection, target_display: &str) -> WaylandLoop {
+impl WaylandBackend {
+    pub fn new(conn: Connection, target_display: &str) -> WaylandBackend {
         let wl_display = conn.display();
         let mut event_queue = conn.new_event_queue();
         let _registry = wl_display.get_registry(&event_queue.handle(), ());
@@ -30,7 +30,7 @@ impl WaylandLoop {
         // Roundtrip a second time to sync the outputs
         event_queue.roundtrip(&mut state).unwrap();
         // TODO: bail out if output management protocol isn't available
-        WaylandLoop { state, event_queue }
+        WaylandBackend { state, event_queue }
     }
 
     fn read_socket(&mut self) {
@@ -45,7 +45,7 @@ impl WaylandLoop {
             .expect("Failed to apply display changes.");
     }
 }
-impl AppLoop for WaylandLoop {
+impl DisplayManager for WaylandBackend {
     fn change_rotation_state(&mut self, new_state: &Orientation) {
         self.read_socket();
 

--- a/src/backends/wlroots.rs
+++ b/src/backends/wlroots.rs
@@ -30,12 +30,9 @@ impl WaylandBackend {
         let mut state = AppData::new(&mut event_queue, target_display.to_string());
         // Roundtrip twice to sync the outputs
         for _ in 0..2 {
-            event_queue.roundtrip(&mut state).map_err(|e| {
-                format!(
-                    "Failed to communicate with the wayland socket: {}",
-                    e.to_string()
-                )
-            })?;
+            event_queue
+                .roundtrip(&mut state)
+                .map_err(|e| format!("Failed to communicate with the wayland socket: {}", e))?;
         }
 
         state
@@ -107,7 +104,7 @@ impl AppData {
             &self.target_head,
         ) {
             let configuration = output_manager.create_configuration(serial, &self.queue_handle, ());
-            let head_config = configuration.enable_head(&head, &self.queue_handle, ());
+            let head_config = configuration.enable_head(head, &self.queue_handle, ());
             head_config.set_transform(new_transform);
             configuration.apply();
         }

--- a/src/backends/xorg.rs
+++ b/src/backends/xorg.rs
@@ -2,14 +2,14 @@ use std::process::Command;
 
 use wayland_client::protocol::wl_output::Transform;
 
-use crate::Orientation;
-
 use super::DisplayManager;
+use crate::Orientation;
 
 pub struct XorgBackend {
     touchscreens: Vec<String>,
     target_display: String,
 }
+
 impl XorgBackend {
     pub fn new(display: &str, touchscreens: Vec<String>) -> Self {
         XorgBackend {
@@ -18,6 +18,7 @@ impl XorgBackend {
         }
     }
 }
+
 impl DisplayManager for XorgBackend {
     fn change_rotation_state(&mut self, new_state: &Orientation) {
         Command::new("xrandr")

--- a/src/backends/xorg.rs
+++ b/src/backends/xorg.rs
@@ -1,0 +1,66 @@
+use std::process::Command;
+
+use crate::Orientation;
+
+use super::AppLoop;
+
+pub struct XLoop {
+    pub touchscreens: Vec<String>,
+}
+impl AppLoop for XLoop {
+    fn tick_always(&mut self) -> () {}
+    fn tick(&mut self, new_state: &Orientation) {
+        Command::new("xrandr")
+            .arg("-o")
+            .arg(new_state.x_state)
+            .spawn()
+            .expect("Xrandr rotate command failed to start")
+            .wait()
+            .expect("Xrandr rotate command wait failed");
+
+        // Support Touchscreen and Styli on some 2-in-1 devices
+        for touchscreen in &self.touchscreens {
+            Command::new("xinput")
+                .arg("set-prop")
+                .arg(touchscreen)
+                .arg("Coordinate Transformation Matrix")
+                .args(new_state.matrix)
+                .spawn()
+                .expect("Xinput rotate command failed to start")
+                .wait()
+                .expect("Xinput rotate command wait failed");
+        }
+    }
+
+    fn get_rotation_state(&self, display: &str) -> Result<String, String> {
+        let raw_rotation_state = String::from_utf8(
+            Command::new("xrandr")
+                .output()
+                .expect("Xrandr get outputs command failed to start")
+                .stdout,
+        )
+        .unwrap();
+        let xrandr_output_pattern = regex::Regex::new(format!(
+                r"^{} connected .+? .+? (normal |inverted |left |right )?\(normal left inverted right x axis y axis\) .+$",
+                regex::escape(display),
+            ).as_str()).unwrap();
+        for xrandr_output_line in raw_rotation_state.split('\n') {
+            if !xrandr_output_pattern.is_match(xrandr_output_line) {
+                continue;
+            }
+
+            let xrandr_output_captures =
+                xrandr_output_pattern.captures(xrandr_output_line).unwrap();
+            if let Some(transform) = xrandr_output_captures.get(1) {
+                return Ok(transform.as_str().to_owned());
+            } else {
+                return Ok("normal".to_owned());
+            }
+        }
+
+        Err(format!(
+            "Unable to determine rotation state: display {} not found in xrandr output",
+            display
+        ))
+    }
+}

--- a/src/backends/xorg.rs
+++ b/src/backends/xorg.rs
@@ -2,21 +2,21 @@ use std::process::Command;
 
 use crate::Orientation;
 
-use super::AppLoop;
+use super::DisplayManager;
 
-pub struct XLoop {
+pub struct XorgBackend {
     touchscreens: Vec<String>,
     target_display: String,
 }
-impl XLoop {
+impl XorgBackend {
     pub fn new(display: &str, touchscreens: Vec<String>) -> Self {
-        XLoop {
+        XorgBackend {
             target_display: display.into(),
             touchscreens,
         }
     }
 }
-impl AppLoop for XLoop {
+impl DisplayManager for XorgBackend {
     fn change_rotation_state(&mut self, new_state: &Orientation) {
         Command::new("xrandr")
             .arg("-o")

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,14 +156,14 @@ fn main() -> Result<(), String> {
                     .unwrap()
                     .is_empty()
             {
-                Box::new(XLoop { touchscreens })
+                Box::new(XLoop::new(display, touchscreens))
             } else {
                 return Err("Unable to find Sway or Xorg procceses".to_owned());
             }
         }
     };
 
-    let old_state_owned = loop_runner.get_rotation_state(display)?;
+    let old_state_owned = loop_runner.get_rotation_state()?;
     let mut old_state = old_state_owned.as_str();
 
     for entry in glob("/sys/bus/iio/devices/iio:device*/in_accel_*_raw").unwrap() {
@@ -200,13 +200,13 @@ fn main() -> Result<(), String> {
             },
             Orientation {
                 vector: (-1.0, 0.0),
-                new_state: "90",
+                new_state: "270",
                 x_state: "right",
                 matrix: ["0", "1", "0", "-1", "0", "1", "0", "0", "1"],
             },
             Orientation {
                 vector: (1.0, 0.0),
-                new_state: "270",
+                new_state: "90",
                 x_state: "left",
                 matrix: ["0", "-1", "1", "1", "0", "0", "0", "0", "1"],
             },
@@ -257,9 +257,8 @@ fn main() -> Result<(), String> {
                 }
             }
 
-            loop_runner.tick_always();
             if current_orient.new_state != old_state {
-                loop_runner.tick(current_orient);
+                loop_runner.change_rotation_state(current_orient);
                 old_state = current_orient.new_state;
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -320,10 +320,10 @@ fn process_exists(proc_name: &str) -> bool {
 
 fn transform_to_env(transform: &Transform) -> &str {
     match transform {
-        &Transform::Normal => "normal",
-        &Transform::_90 => "270",
-        &Transform::_180 => "inverted",
-        &Transform::_270 => "90",
-        &_ => "normal",
+        Transform::Normal => "normal",
+        Transform::_90 => "270",
+        Transform::_180 => "inverted",
+        Transform::_270 => "90",
+        _ => "normal",
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,7 +158,7 @@ fn main() -> Result<(), String> {
             {
                 Box::new(XLoop::new(display, touchscreens))
             } else {
-                return Err("Unable to find Sway or Xorg procceses".to_owned());
+                return Err("Unable to find Sway or Xorg processes".to_owned());
             }
         }
     };

--- a/src/wayland_app.rs
+++ b/src/wayland_app.rs
@@ -1,0 +1,156 @@
+use wayland_client::{
+    event_created_child,
+    protocol::{wl_output::Transform, wl_registry},
+    Connection, Dispatch, EventQueue, QueueHandle,
+};
+use wayland_protocols_wlr::output_management::v1::client::{
+    zwlr_output_configuration_head_v1::{self, ZwlrOutputConfigurationHeadV1},
+    zwlr_output_configuration_v1::{self, ZwlrOutputConfigurationV1},
+    zwlr_output_head_v1::{self, ZwlrOutputHeadV1},
+    zwlr_output_manager_v1::{self, ZwlrOutputManagerV1},
+    zwlr_output_mode_v1::{self, ZwlrOutputModeV1},
+};
+
+pub struct AppData {
+    target_display_name: String,
+    target_head: Option<ZwlrOutputHeadV1>,
+    output_manager: Option<ZwlrOutputManagerV1>,
+    current_config_serial: Option<u32>,
+    queue_handle: QueueHandle<AppData>,
+}
+
+// Public interface
+
+impl AppData {
+    pub fn new(event_queue: &mut EventQueue<AppData>, target_display_name: String) -> AppData {
+        AppData {
+            target_display_name,
+            queue_handle: event_queue.handle(),
+            target_head: None,
+            output_manager: None,
+            current_config_serial: None,
+        }
+    }
+
+    pub fn update_configuration(&mut self, new_transform: Transform) {
+        let output_manager = self
+            .output_manager
+            .as_ref()
+            .expect("Failed to create wayland output manager.");
+        // The serial should be replaced after applying the new config, so we can
+        // avoid cloning here.
+        let current_serial = std::mem::replace(&mut self.current_config_serial, None)
+            .expect("Failed to get current config.");
+        let target_head = self
+            .target_head
+            .as_ref()
+            .expect("Failed to get target head.");
+        let configuration =
+            output_manager.create_configuration(current_serial, &self.queue_handle, ());
+        let head_config = configuration.enable_head(&target_head, &self.queue_handle, ());
+        head_config.set_transform(new_transform);
+        configuration.apply();
+    }
+}
+
+// Event handlers
+
+impl Dispatch<wl_registry::WlRegistry, ()> for AppData {
+    fn event(
+        _state: &mut Self,
+        registry: &wl_registry::WlRegistry,
+        event: wl_registry::Event,
+        _: &(),
+        _: &Connection,
+        qh: &QueueHandle<AppData>,
+    ) {
+        if let wl_registry::Event::Global {
+            name,
+            interface,
+            version,
+        } = event
+        {
+            if interface == "zwlr_output_manager_v1" {
+                _state.output_manager =
+                    Some(registry.bind::<ZwlrOutputManagerV1, (), AppData>(name, version, qh, ()));
+            }
+        }
+    }
+}
+
+impl Dispatch<ZwlrOutputManagerV1, ()> for AppData {
+    fn event(
+        _state: &mut Self,
+        _: &ZwlrOutputManagerV1,
+        event: zwlr_output_manager_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<AppData>,
+    ) {
+        if let zwlr_output_manager_v1::Event::Done { serial } = event {
+            _state.current_config_serial = Some(serial);
+        }
+    }
+
+    event_created_child!(AppData, ZwlrOutputHeadV1, [
+       zwlr_output_manager_v1::EVT_HEAD_OPCODE => (ZwlrOutputHeadV1, ()),
+    ]);
+}
+
+impl Dispatch<ZwlrOutputHeadV1, ()> for AppData {
+    fn event(
+        _state: &mut Self,
+        head: &ZwlrOutputHeadV1,
+        event: zwlr_output_head_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<AppData>,
+    ) {
+        if let zwlr_output_head_v1::Event::Name { name } = event {
+            if name == _state.target_display_name {
+                _state.target_head = Some(head.clone());
+            }
+        }
+    }
+
+    event_created_child!(AppData, ZwlrOutputModeV1, [
+       zwlr_output_head_v1::EVT_CURRENT_MODE_OPCODE => (ZwlrOutputModeV1, ()),
+       zwlr_output_head_v1::EVT_MODE_OPCODE => (ZwlrOutputModeV1, ()),
+    ]);
+}
+
+impl Dispatch<ZwlrOutputModeV1, ()> for AppData {
+    fn event(
+        _state: &mut Self,
+        _: &ZwlrOutputModeV1,
+        _: zwlr_output_mode_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<AppData>,
+    ) {
+    }
+}
+
+impl Dispatch<ZwlrOutputConfigurationV1, ()> for AppData {
+    fn event(
+        _state: &mut Self,
+        _: &ZwlrOutputConfigurationV1,
+        _: zwlr_output_configuration_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<AppData>,
+    ) {
+    }
+}
+
+impl Dispatch<ZwlrOutputConfigurationHeadV1, ()> for AppData {
+    fn event(
+        _state: &mut Self,
+        _: &ZwlrOutputConfigurationHeadV1,
+        _: zwlr_output_configuration_head_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<AppData>,
+    ) {
+    }
+}


### PR DESCRIPTION
Switches to using the `wlr_output_management_v1` protocol for any wayland compositors which support it, expanding screen rotation support to them. I've omitted a version bump, but I think this change definitely justifies at least a minor version bump. It seems like the options interface is also pretty stable and this would _technically_ break `rot8` for anyone using ancient versions of sway without the output management protocol, so maybe this justifies a 1.0.0 release :slightly_smiling_face: 

Resolves #5 

## Design

This uses the safe wayland-rs wrappers to communicate with the wayland socket on startup. If it's accessible and advertises support for output management, the wayland backend will be selected. If `sway` is running, a specialized sway backend will be used instead. If wayland can't be connected to, it will check if X11 is running and switch to it like the existing impl does. If neither the output management protocol nor an X11 process exist, it will exit with an error.

I chose to drop the sway-specific rotation method in the interest of code sharing & simplicity. I think this is a good tradeoff, since sway has supported the output_management protocol for a very long time, and communicating via the socket seems to be a bit snappier than the subprocess call. This does interact a bit awkwardly with #45 though (see inline comment).

Since working with the wayland protocols requires a lot of event listener code, `main.rs` would have gotten pretty inscrutable if I had sprinkled the per-backend logic throughout `main.rs` like the current implementation does. So I decided to move all the platform-specific logic into a `DisplayManager` trait, with one struct per implementation. The `SwayBackend` implementation simply wraps the `WaylandBackend`, to preserve keyboard disabling functionality. The logic for the `XorgBackend` should be entirely unchanged, besides making the touchscreens argument `Vec<String>` instead of `Vec<&str>`. This design makes the main loop easier to understand, and keeps all the platform-specific code nice and centralized.

## Testing

Tested thoroughly on Sway and Hyprland where I have been using this branch for a few weeks (minus the merge commit). I also tested the `--disable-keyboards` option on Sway, and rotation with exwm, which was the only X window manager I have lying around. Since the main event loop works the same way and the wayland socket is not read/written unless the orientation changed, performance is not noticeably different.
