### PR TITLE
add temporary hyprland backend

### DIFF
--- a/src/backends/hyprland.rs
+++ b/src/backends/hyprland.rs
@@ -1,0 +1,57 @@
+use std::process::{Command, Stdio};
+
+use wayland_client::protocol::wl_output::Transform;
+
+use crate::Orientation;
+
+use super::{wlroots::WaylandBackend, DisplayManager};
+
+// TODO: remove when https://github.com/hyprwm/Hyprland/pull/3544 gets merged
+// as per the wiki: https://wiki.hyprland.org/Configuring/Monitors/#rotating
+pub struct HyprlandBackend {
+    wayland_backend: WaylandBackend,
+}
+
+impl HyprlandBackend {
+    pub fn new(wayland_backend: WaylandBackend) -> Self {
+        HyprlandBackend {
+            wayland_backend,
+        }
+    }
+
+    // https://wiki.hyprland.org/Configuring/Monitors/#rotating
+    fn get_transform_idx(transform: Transform) -> Option<u8> {
+        match transform {
+            Transform::Normal => Some(0),
+            Transform::_90 => Some(1),
+            Transform::_180 => Some(2),
+            Transform::_270 => Some(3),
+            Transform::Flipped => Some(4),
+            Transform::Flipped90 => Some(5),
+            Transform::Flipped180 => Some(6),
+            Transform::Flipped270 => Some(7),
+            _ => None,
+        }
+    }
+}
+
+impl DisplayManager for HyprlandBackend {
+    fn change_rotation_state(&mut self, new_state: &Orientation) {
+        self.wayland_backend.change_rotation_state(new_state);
+        let transform_idx = HyprlandBackend::get_transform_idx(new_state.wayland_state)
+            .expect("unknown transform");
+        Command::new("hyprctl")
+            .arg("keyword")
+            .arg("input:touchdevice:transform")
+            .arg(transform_idx.to_string())
+            .stdout(Stdio::null())
+            .spawn()
+            .expect("hyprctl touchdevice transform command failed to start")
+            .wait()
+            .expect("hyprctl touchdevice transform command wait failed");
+    }
+
+    fn get_rotation_state(&mut self) -> Result<Transform, String> {
+        self.wayland_backend.get_rotation_state()
+    }
+}

--- a/src/backends/hyprland.rs
+++ b/src/backends/hyprland.rs
@@ -49,6 +49,15 @@ impl DisplayManager for HyprlandBackend {
             .expect("hyprctl touchdevice transform command failed to start")
             .wait()
             .expect("hyprctl touchdevice transform command wait failed");
+        Command::new("hyprctl")
+            .arg("keyword")
+            .arg("input:tablet:transform")
+            .arg(transform_idx.to_string())
+            .stdout(Stdio::null())
+            .spawn()
+            .expect("hyprctl tablet transform command failed to start")
+            .wait()
+            .expect("hyprctl tablet transform command wait failed");
     }
 
     fn get_rotation_state(&mut self) -> Result<Transform, String> {

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -9,6 +9,7 @@ pub trait DisplayManager {
     fn get_rotation_state(&mut self) -> Result<Transform, String>;
 }
 
+pub mod hyprland;
 pub mod sway;
 pub mod wlroots;
 pub mod xorg;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use glob::glob;
 use wayland_client::protocol::wl_output::Transform;
 
 mod backends;
-use backends::{sway::SwayBackend, wlroots::WaylandBackend, xorg::XorgBackend, DisplayManager};
+use backends::{hyprland::HyprlandBackend, sway::SwayBackend, wlroots::WaylandBackend, xorg::XorgBackend, DisplayManager};
 
 const ROT8_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -163,7 +163,9 @@ fn main() -> Result<(), String> {
 
     let mut backend: Box<dyn DisplayManager> = match WaylandBackend::new(display) {
         Ok(wayland_backend) => {
-            if process_exists("sway") {
+            if process_exists("Hyprland") {
+                Box::new(HyprlandBackend::new(wayland_backend))
+            } else if process_exists("sway") {
                 Box::new(SwayBackend::new(wayland_backend, disable_keyboard))
             } else {
                 Box::new(wayland_backend)


### PR DESCRIPTION
to be removed when https://github.com/hyprwm/Hyprland/pull/3544 is merged

wiki note: https://wiki.hyprland.org/Configuring/Monitors/#rotating