### PR TITLE
Fix xrandr output regex

### DIFF
--- a/src/backends/xorg.rs
+++ b/src/backends/xorg.rs
@@ -52,7 +52,7 @@ impl DisplayManager for XorgBackend {
         )
         .unwrap();
         let xrandr_output_pattern = regex::Regex::new(format!(
-                r"^{} connected .+? .+? (normal |inverted |left |right )?\(normal left inverted right x axis y axis\) .+$",
+                r"^{} connected .+? .*? (normal |inverted |left |right )?\(normal left inverted right x axis y axis\) .+$",
                 regex::escape(&self.target_display),
             ).as_str()).unwrap();
         for xrandr_output_line in raw_rotation_state.split('\n') {


### PR DESCRIPTION
Make the actual orientation optional in the regexp as the xrandr output may not include it after the " connected " keyword.